### PR TITLE
Update core-graphics dependency to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ libc = "0.2"
 
 [target.x86_64-apple-darwin.dependencies]
 core-foundation = "0.2"
-core-graphics = "0.1.2"
+core-graphics = "0.2"


### PR DESCRIPTION
This is what the rest of Servo is using -- so bump it here as well to
avoid test-tidy failure.

Note that this is indeed the version Servo is currently using core-text
with (as Servo still has a revision of core-text that didn't specify any
version constraints) -- so we are rather certain that this combination
works.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/46)
<!-- Reviewable:end -->
