### PR TITLE
Add binding for CTFontGetUnitsPerEm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"

--- a/src/font.rs
+++ b/src/font.rs
@@ -254,6 +254,12 @@ impl CTFont {
         }
     }
 
+    pub fn units_per_em(&self) -> libc::c_uint {
+        unsafe {
+            CTFontGetUnitsPerEm(self.obj)
+        }
+    }
+
     pub fn x_height(&self) -> CGFloat {
         unsafe {
             CTFontGetXHeight(self.obj)
@@ -457,7 +463,7 @@ extern {
     fn CTFontGetAscent(font: CTFontRef) -> CGFloat;
     fn CTFontGetDescent(font: CTFontRef) -> CGFloat;
     fn CTFontGetLeading(font: CTFontRef) -> CGFloat;
-    //fn CTFontGetUnitsPerEm(font: CTFontRef) -> libc::c_uint;
+    fn CTFontGetUnitsPerEm(font: CTFontRef) -> libc::c_uint;
     //fn CTFontGetGlyphCount
     fn CTFontGetBoundingBox(font: CTFontRef) -> CGRect;
     fn CTFontGetUnderlinePosition(font: CTFontRef) -> CGFloat;


### PR DESCRIPTION
Needed for implementing fast-path kerning on Mac OS. r? @pcwalton

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/50)
<!-- Reviewable:end -->
