### PR TITLE
font_path may be null

### DIFF
--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -271,15 +271,17 @@ impl CTFontDescriptor {
         value.expect("A font must have a non-null display name.")
     }
 
-    pub fn font_path(&self) -> String {
+    pub fn font_path(&self) -> Option<String> {
         unsafe {
             let value = CTFontDescriptorCopyAttribute(self.obj, kCTFontURLAttribute);
-            assert!(!value.is_null());
+            if (value.is_null()) {
+                return None;
+            }
 
             let value: CFType = TCFType::wrap_under_get_rule(value);
             assert!(value.instance_of::<CFURLRef,CFURL>());
             let url: CFURL = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
-            format!("{:?}", url)
+            Some(format!("{:?}", url))
         }
     }
 }
@@ -297,7 +299,7 @@ pub fn debug_descriptor(desc: &CTFontDescriptor) {
     println!("name: {}", desc.font_name());
     println!("style: {}", desc.style_name());
     println!("display: {}", desc.display_name());
-    println!("path: {}", desc.font_path());
+    println!("path: {:?}", desc.font_path());
     desc.show();
 }
 


### PR DESCRIPTION
Given PR #57, we can quite easily get `CTFontDescriptor` that returns `null` for the `font_path`.

In the default font chains I've seen at least two fonts that are part of the chains but we can't get the `font_path`. Interestingly the font names and family names are prefixed with a `.` as if to indicate they are internal:

      ".Apple Symbols Fallback",
      ".Noto Sans Universal",

This is a breaking change, so may be undesirable, but I think it requires discussion.


Here's the full fallback list for `Menlo` and language `en`.

```
      "Monaco",
      ".Apple Symbols Fallback",
      "Lucida Grande",
      "Courier New",
      "Ayuthaya",
      "Kailasa",
      "PingFang SC",
      "PingFang TC",
      "Hiragino Sans",
      "Hiragino Sans GB",
      "Apple SD Gothic Neo",
      "PingFang HK",
      "Kohinoor Bangla",
      "Kohinoor Devanagari",
      "Gujarati Sangam MN",
      "Gurmukhi MN",
      "Kannada Sangam MN",
      "Khmer Sangam MN",
      "Lao Sangam MN",
      "Malayalam Sangam MN",
      "Myanmar Sangam MN",
      "Oriya Sangam MN",
      "Sinhala Sangam MN",
      "Tamil Sangam MN",
      "Kohinoor Telugu",
      "Mshtakan",
      "Euphemia UCAS",
      "Plantagenet Cherokee",
      ".Noto Sans Universal",
      "Apple Color Emoji"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/58)
<!-- Reviewable:end -->
