### PR TITLE
Add a lion feature for 10.7 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "core-text"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"
 repository = "https://github.com/servo/core-text-rs"
+
+[features]
+default = []
+# For OS X 10.7 compat, use this feature. It will exclude some things
+lion = []
 
 [dependencies]
 libc = "0.2"

--- a/src/font.rs
+++ b/src/font.rs
@@ -379,6 +379,7 @@ pub fn debug_font_traits(font: &CTFont) {
 //    println!("kCTFontSlantTrait: {}", traits.normalized_slant());
 }
 
+#[cfg(not(feature = "lion"))]
 pub fn cascade_list_for_languages(font: &CTFont, language_pref_list: &CFArray) -> CFArray {
     unsafe {
         let font_collection_ref =
@@ -463,6 +464,7 @@ extern {
     fn CTFontCopyName(font: CTFontRef, nameKey: CFStringRef) -> CFStringRef;
     //fn CTFontCopyLocalizedName(font: CTFontRef, nameKey: CFStringRef, 
     //                           language: *CFStringRef) -> CFStringRef;
+    #[cfg(not(feature = "lion"))]
     fn CTFontCopyDefaultCascadeListForLanguages(font: CTFontRef, languagePrefList: CFArrayRef) -> CFArrayRef;
 
 


### PR DESCRIPTION
This allows #57 to build on OS X 10.7, if built with the "lion" feature. This is modeled on the "elcapitan" feature in core-graphics-rs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/61)
<!-- Reviewable:end -->
