### PR TITLE
Deal with two ultra-trivial warnings

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -307,11 +307,11 @@ impl CTFont {
     pub fn get_bounding_rects_for_glyphs(&self, orientation: CTFontOrientation, glyphs: &[CGGlyph])
                                          -> CGRect {
         unsafe {
-            let mut result = CTFontGetBoundingRectsForGlyphs(self.as_concrete_TypeRef(),
-                                                             orientation,
-                                                             glyphs.as_ptr(),
-                                                             ptr::null_mut(),
-                                                             glyphs.len() as CFIndex);
+            let result = CTFontGetBoundingRectsForGlyphs(self.as_concrete_TypeRef(),
+                                                         orientation,
+                                                         glyphs.as_ptr(),
+                                                         ptr::null_mut(),
+                                                         glyphs.len() as CFIndex);
             result
         }
     }

--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -274,7 +274,7 @@ impl CTFontDescriptor {
     pub fn font_path(&self) -> Option<String> {
         unsafe {
             let value = CTFontDescriptorCopyAttribute(self.obj, kCTFontURLAttribute);
-            if (value.is_null()) {
+            if value.is_null() {
                 return None;
             }
 


### PR DESCRIPTION
I was too lazy to set git up and clone the repo locally, so these are the only warnings from the mondo list in #62 that I could do anything about right now. I'd like to get to at least some of the rest—the private-type-in-public-interface ones seem at first glance to be pretty doable, but I'd need to be able to run the compiler over the code to check for cascades.

(The fact I did this entirely in the Github UI also means I couldn't squash the two commits myself. Sorry.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/64)
<!-- Reviewable:end -->
