### PR TITLE
Fix core-text related warnings (#62)

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -23,7 +23,7 @@ use core_graphics::context::{CGContext, CGContextRef};
 use core_graphics::font::{CGGlyph, CGFont, CGFontRef};
 use core_graphics::geometry::{CGPoint, CGRect, CGSize};
 
-use libc::{self, size_t};
+use libc::{self, size_t, c_void};
 use std::mem;
 use std::ptr;
 
@@ -70,7 +70,7 @@ pub const kCTFontOptionsPreventAutoActivation: CTFontOptions = (1 << 0);
 pub const kCTFontOptionsPreferSystemFont: CTFontOptions = (1 << 2);
 
 #[repr(C)]
-struct __CTFont;
+pub struct __CTFont(c_void);
 
 pub type CTFontRef = *const __CTFont;
 
@@ -193,23 +193,31 @@ impl CTFont {
 
     // Names
     pub fn family_name(&self) -> String {
-        let value = get_string_by_name_key(self, kCTFontFamilyNameKey);
-        value.expect("Fonts should always have a family name.")
+        unsafe {
+            let value = get_string_by_name_key(self, kCTFontFamilyNameKey);
+            value.expect("Fonts should always have a family name.")
+        }
     }
 
     pub fn face_name(&self) -> String {
-        let value = get_string_by_name_key(self, kCTFontSubFamilyNameKey);
-        value.expect("Fonts should always have a face name.")
+        unsafe {
+            let value = get_string_by_name_key(self, kCTFontSubFamilyNameKey);
+            value.expect("Fonts should always have a face name.")
+        }
     }
 
     pub fn unique_name(&self) -> String {
-        let value = get_string_by_name_key(self, kCTFontUniqueNameKey);
-        value.expect("Fonts should always have a unique name.")
+        unsafe {
+            let value = get_string_by_name_key(self, kCTFontUniqueNameKey);
+            value.expect("Fonts should always have a unique name.")
+        }
     }
 
     pub fn postscript_name(&self) -> String {
-        let value = get_string_by_name_key(self, kCTFontPostScriptNameKey);
-        value.expect("Fonts should always have a PostScript name.")
+        unsafe {
+            let value = get_string_by_name_key(self, kCTFontPostScriptNameKey);
+            value.expect("Fonts should always have a PostScript name.")
+        }
     }
 
     pub fn all_traits(&self) -> CTFontTraits {
@@ -357,12 +365,14 @@ pub fn debug_font_names(font: &CTFont) {
         get_string_by_name_key(font, key).unwrap()
     }
 
-    println!("kCTFontFamilyNameKey: {}", get_key(font, kCTFontFamilyNameKey));
-    println!("kCTFontSubFamilyNameKey: {}", get_key(font, kCTFontSubFamilyNameKey));
-    println!("kCTFontStyleNameKey: {}", get_key(font, kCTFontStyleNameKey));
-    println!("kCTFontUniqueNameKey: {}", get_key(font, kCTFontUniqueNameKey));
-    println!("kCTFontFullNameKey: {}", get_key(font, kCTFontFullNameKey));
-    println!("kCTFontPostScriptNameKey: {}", get_key(font, kCTFontPostScriptNameKey));
+    unsafe {
+        println!("kCTFontFamilyNameKey: {}", get_key(font, kCTFontFamilyNameKey));
+        println!("kCTFontSubFamilyNameKey: {}", get_key(font, kCTFontSubFamilyNameKey));
+        println!("kCTFontStyleNameKey: {}", get_key(font, kCTFontStyleNameKey));
+        println!("kCTFontUniqueNameKey: {}", get_key(font, kCTFontUniqueNameKey));
+        println!("kCTFontFullNameKey: {}", get_key(font, kCTFontFullNameKey));
+        println!("kCTFontPostScriptNameKey: {}", get_key(font, kCTFontPostScriptNameKey));
+    }
 }
 
 pub fn debug_font_traits(font: &CTFont) {

--- a/src/font_collection.rs
+++ b/src/font_collection.rs
@@ -18,11 +18,12 @@ use core_foundation::number::CFNumber;
 use core_foundation::set::CFSet;
 use core_foundation::string::{CFString, CFStringRef};
 
+use libc::c_void;
 use std::mem;
 use std::ptr;
 
 #[repr(C)]
-struct __CTFontCollection;
+pub struct __CTFontCollection(c_void);
 
 pub type CTFontCollectionRef = *const __CTFontCollection;
 

--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -18,6 +18,7 @@ use core_foundation::string::{CFString, CFStringRef};
 use core_foundation::url::{CFURL, CFURLRef};
 use core_graphics::base::CGFloat;
 
+use libc::c_void;
 use std::mem;
 
 /*
@@ -182,7 +183,7 @@ pub const kCTFontPriorityDynamic: CTFontPriority = 50000;
 pub const kCTFontPriorityProcess: CTFontPriority = 60000;
 
 #[repr(C)]
-struct __CTFontDescriptor;
+pub struct __CTFontDescriptor(c_void);
 
 pub type CTFontDescriptorRef = *const __CTFontDescriptor;
 
@@ -252,23 +253,31 @@ impl CTFontDescriptor {
 
 impl CTFontDescriptor {
     pub fn family_name(&self) -> String {
-        let value = self.get_string_attribute(kCTFontDisplayNameAttribute);
-        value.expect("A font2 must have a non-null font family name.")
+        unsafe {
+            let value = self.get_string_attribute(kCTFontDisplayNameAttribute);
+            value.expect("A font2 must have a non-null font family name.")
+        }
     }
 
     pub fn font_name(&self) -> String {
-        let value = self.get_string_attribute(kCTFontNameAttribute);
-        value.expect("A font must have a non-null name.")
+        unsafe {
+            let value = self.get_string_attribute(kCTFontNameAttribute);
+            value.expect("A font must have a non-null name.")
+        }
     }
 
     pub fn style_name(&self) -> String {
-        let value = self.get_string_attribute(kCTFontStyleNameAttribute);
-        value.expect("A font must have a non-null style name.")
+        unsafe {
+            let value = self.get_string_attribute(kCTFontStyleNameAttribute);
+            value.expect("A font must have a non-null style name.")
+        }
     }
 
     pub fn display_name(&self) -> String {
-        let value = self.get_string_attribute(kCTFontDisplayNameAttribute);
-        value.expect("A font must have a non-null display name.")
+        unsafe {
+            let value = self.get_string_attribute(kCTFontDisplayNameAttribute);
+            value.expect("A font must have a non-null display name.")
+        }
     }
 
     pub fn font_path(&self) -> Option<String> {


### PR DESCRIPTION
### Fix private-in-public warnings (error E0446)
Fixed by prepending `pub` to the offending types. Not sure if its the best way but it was the only thing that worked. Other methods I've tried to maintain privateness:
* Replace with an empty enum. That threw an error. 
* Make it public and wrap within a private module. That threw an error too as `#[repr(C)]` does not accept modules 

### Fix use of extern static warnings by wrapping in unsafe block (error E0133)
I think this is self-explanatory. 

### Fix zero-size struct warnings on certain CT* types
Wrap around c_void as I believe the types are only used as pointers. Again, let me know if there is a better way to do this. I've tried following [this discussion](https://github.com/rust-lang/rust/issues/27303) on opaque C types but I don't think there is a consensus. I came across this [discussion](https://github.com/AngryLawyer/rust-sdl2/issues/442) from the Rust SDL2 bindings and they eventually [opted](https://github.com/AngryLawyer/rust-sdl2/pull/445) for the solution that I implemented. 

This is my first pull request (hence, first open source contribution) and I've been playing with Rust for the past few weeks. So please, if anything isnt up to standards or correctness, let me know! Also, to squash the other warnings, those changes would have to made in the modules where those types reside (core-graphics and core-foundation). I would gladly open a PR to fix those too if all looks good. 

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/65)
<!-- Reviewable:end -->
