### PR TITLE
Temporarily override the improper_ctypes warning #62.

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -399,6 +399,8 @@ pub fn cascade_list_for_languages(font: &CTFont, language_pref_list: &CFArray) -
     }
 }
 
+// TODO - Remove the warning override once this is solved in core-foundation
+#[allow(improper_ctypes)]
 #[link(name = "ApplicationServices", kind = "framework")]
 extern {
     /*

--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -312,6 +312,8 @@ pub fn debug_descriptor(desc: &CTFontDescriptor) {
     desc.show();
 }
 
+// TODO - Remove the warning override once this is solved in core-graphics
+#[allow(improper_ctypes)]
 extern {
     /*
      * CTFontTraits.h


### PR DESCRIPTION
The remaining warnings are from types in
core-foundation(CGAffineTransform) and core-graphics(CFNumberRef). When
they are rectified the warnings can be turned back on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/67)
<!-- Reviewable:end -->
