### PR TITLE
Bump foundation and graphics versions for #62.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "6.1.0"
+version = "6.1.1"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ mountainlion = []
 libc = "0.2"
 
 [target.x86_64-apple-darwin.dependencies]
-core-foundation = "0.3"
-core-graphics = "0.8"
+core-foundation = "0.4"
+core-graphics = "0.9"


### PR DESCRIPTION
This removes the last of the compiler warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/68)
<!-- Reviewable:end -->
