### PR TITLE
Major version bump for dependencies bump - #62

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "6.1.2"
+version = "7.0.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"
@@ -16,5 +16,5 @@ mountainlion = []
 libc = "0.2"
 
 [target.x86_64-apple-darwin.dependencies]
-core-foundation = "0.3"
-core-graphics = "0.8"
+core-foundation = "0.4"
+core-graphics = "0.9"


### PR DESCRIPTION
Due to servo/webrender#1592 the dependency upgrade was reverted for 6.x
and added to 7.x.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/71)
<!-- Reviewable:end -->
