### PR TITLE
Update to the latest `core-graphics-rs` and add a binding for `CTFontCreatePathForGlyph()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ default = ["mountainlion"]
 mountainlion = []
 
 [dependencies]
+foreign-types = "0.3"
 libc = "0.2"
 
 [target.x86_64-apple-darwin.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ libc = "0.2"
 
 [target.x86_64-apple-darwin.dependencies]
 core-foundation = "0.4"
-core-graphics = "0.9"
+core-graphics = "0.11"

--- a/src/font.rs
+++ b/src/font.rs
@@ -22,6 +22,7 @@ use core_graphics::base::CGFloat;
 use core_graphics::context::CGContext;
 use core_graphics::font::{CGGlyph, CGFont};
 use core_graphics::geometry::{CGAffineTransform, CGPoint, CGRect, CGSize};
+use core_graphics::path::CGPath;
 
 use foreign_types::ForeignType;
 use libc::{self, size_t, c_void};
@@ -350,6 +351,18 @@ impl CTFont {
             }
         }
     }
+
+    pub fn create_path_for_glyph(&self, glyph: CGGlyph, matrix: &CGAffineTransform)
+                                 -> Result<CGPath, ()> {
+        unsafe {
+            let path = CTFontCreatePathForGlyph(self.obj, glyph, matrix);
+            if path.is_null() {
+                Err(())
+            } else {
+                Ok(CGPath::from_ptr(path))
+            }
+        }
+    }
 }
 
 // Helper methods
@@ -502,7 +515,8 @@ extern {
     fn CTFontGetXHeight(font: CTFontRef) -> CGFloat;
 
     /* Getting Glyph Data */
-    //fn CTFontCreatePathForGlyph
+    fn CTFontCreatePathForGlyph(font: CTFontRef, glyph: CGGlyph, matrix: *const CGAffineTransform)
+                                -> CGPathRef;
     //fn CTFontGetGlyphWithName
     fn CTFontGetBoundingRectsForGlyphs(font: CTFontRef,
                                        orientation: CTFontOrientation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 
 #![allow(non_snake_case)]
 
+extern crate foreign_types;
 extern crate libc;
 
 extern crate core_foundation;


### PR DESCRIPTION
This is needed for Pathfinder.

r? anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/72)
<!-- Reviewable:end -->
