### PR TITLE
Add iOS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,5 @@ mountainlion = []
 [dependencies]
 foreign-types = "0.3"
 libc = "0.2"
-
-[target.x86_64-apple-darwin.dependencies]
 core-foundation = "0.4"
 core-graphics = "0.11"

--- a/src/font.rs
+++ b/src/font.rs
@@ -417,7 +417,7 @@ pub fn cascade_list_for_languages(font: &CTFont, language_pref_list: &CFArray) -
     }
 }
 
-#[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "CoreText", kind = "framework")]
 extern {
     /*
      * CTFont.h


### PR DESCRIPTION
Ability to build core-text-rs for iOS platform have been added in this PR.
For building could be used:
cargo build --target aarch64-apple-ios

@larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/73)
<!-- Reviewable:end -->
