### PR TITLE
Upgrade core foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ mountainlion = []
 [dependencies]
 foreign-types = "0.3"
 libc = "0.2"
-core-foundation = "0.4"
-core-graphics = "0.12.1"
+core-foundation = "0.5"
+core-graphics = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "8.0.0"
+version = "9.0.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"

--- a/src/font.rs
+++ b/src/font.rs
@@ -102,7 +102,9 @@ impl Clone for CTFont {
     }
 }
 
-impl TCFType<CTFontRef> for CTFont {
+impl TCFType for CTFont {
+    type Ref = CTFontRef;
+
     #[inline]
     fn as_concrete_TypeRef(&self) -> CTFontRef {
         self.obj

--- a/src/font_collection.rs
+++ b/src/font_collection.rs
@@ -40,7 +40,9 @@ impl Drop for CTFontCollection {
     }
 }
 
-impl TCFType<CTFontCollectionRef> for CTFontCollection {
+impl TCFType for CTFontCollection {
+    type Ref = CTFontCollectionRef;
+
     #[inline]
     fn as_concrete_TypeRef(&self) -> CTFontCollectionRef {
         self.obj

--- a/src/font_collection.rs
+++ b/src/font_collection.rs
@@ -89,7 +89,7 @@ impl CTFontCollection {
 pub fn new_from_descriptors(descs: &CFArray) -> CTFontCollection {
     unsafe {
         let key: CFString = TCFType::wrap_under_get_rule(kCTFontCollectionRemoveDuplicatesOption);
-        let value = CFNumber::from_i64(1);
+        let value = CFNumber::from(1i64);
         let options = CFDictionary::from_CFType_pairs(&[ (key.as_CFType(), value.as_CFType()) ]);
         let font_collection_ref =
             CTFontCollectionCreateWithFontDescriptors(descs.as_concrete_TypeRef(),
@@ -101,7 +101,7 @@ pub fn new_from_descriptors(descs: &CFArray) -> CTFontCollection {
 pub fn create_for_all_families() -> CTFontCollection {
     unsafe {
         let key: CFString = TCFType::wrap_under_get_rule(kCTFontCollectionRemoveDuplicatesOption);
-        let value = CFNumber::from_i64(1);
+        let value = CFNumber::from(1i64);
         let options = CFDictionary::from_CFType_pairs(&[ (key.as_CFType(), value.as_CFType()) ]);
         let font_collection_ref =
             CTFontCollectionCreateFromAvailableFonts(options.as_concrete_TypeRef());

--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -15,7 +15,7 @@ use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::number::{CFNumber, CFNumberRef};
 use core_foundation::set::CFSetRef;
 use core_foundation::string::{CFString, CFStringRef};
-use core_foundation::url::{CFURL, CFURLRef};
+use core_foundation::url::CFURL;
 use core_graphics::base::CGFloat;
 
 use libc::c_void;
@@ -130,7 +130,7 @@ trait TraitAccessorPrivate {
 impl TraitAccessorPrivate for CTFontTraits {
     unsafe fn extract_number_for_key(&self, key: CFStringRef) -> CFNumber {
         let cftype = self.get_CFType(mem::transmute(key));
-        assert!(cftype.instance_of::<CFNumberRef,CFNumber>());
+        assert!(cftype.instance_of::<CFNumber>());
         TCFType::wrap_under_get_rule(mem::transmute(cftype.as_CFTypeRef()))
     }
 
@@ -200,7 +200,9 @@ impl Drop for CTFontDescriptor {
     }
 }
 
-impl TCFType<CTFontDescriptorRef> for CTFontDescriptor {
+impl TCFType for CTFontDescriptor {
+    type Ref = CTFontDescriptorRef;
+
     #[inline]
     fn as_concrete_TypeRef(&self) -> CTFontDescriptorRef {
         self.obj
@@ -243,7 +245,7 @@ impl CTFontDescriptor {
             }
 
             let value: CFType = TCFType::wrap_under_get_rule(value);
-            assert!(value.instance_of::<CFStringRef,CFString>());
+            assert!(value.instance_of::<CFString>());
             let s: CFString = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
             Some(s.to_string())
         }
@@ -288,7 +290,7 @@ impl CTFontDescriptor {
             }
 
             let value: CFType = TCFType::wrap_under_get_rule(value);
-            assert!(value.instance_of::<CFURLRef,CFURL>());
+            assert!(value.instance_of::<CFURL>());
             let url: CFURL = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
             Some(format!("{:?}", url))
         }


### PR DESCRIPTION
This is a PR in a series of PRs originating at https://github.com/servo/core-foundation-rs/pull/132

The plan is to make a breaking change to `core-foundation` and release it as `0.5.0`. But before the merge/publish of `core-foundation` I will prepare a set of PRs making sure the entire dependency graph of Servo is ready for this change and can be switched over to `0.5.0` directly

TODO before merge:
- [x] Merge `core-foundation` PR and publish.
- [x] Merge `core-graphics` PR and publish.
- [x] Remove the last commit from this PR, so we depend on `core-foundation` from crates.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/75)
<!-- Reviewable:end -->
