### PR TITLE
Have font_path() return a PathBuf instead of a String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "9.0.0"
+version = "10.0.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"

--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -20,6 +20,7 @@ use core_graphics::base::CGFloat;
 
 use libc::c_void;
 use std::mem;
+use std::path::PathBuf;
 
 /*
 * CTFontTraits.h
@@ -282,7 +283,7 @@ impl CTFontDescriptor {
         }
     }
 
-    pub fn font_path(&self) -> Option<String> {
+    pub fn font_path(&self) -> Option<PathBuf> {
         unsafe {
             let value = CTFontDescriptorCopyAttribute(self.obj, kCTFontURLAttribute);
             if value.is_null() {
@@ -292,7 +293,7 @@ impl CTFontDescriptor {
             let value: CFType = TCFType::wrap_under_get_rule(value);
             assert!(value.instance_of::<CFURL>());
             let url: CFURL = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
-            Some(format!("{:?}", url))
+            url.to_path()
         }
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/78)
<!-- Reviewable:end -->
