### PR TITLE
Properly release attribute returned by CTFontDescriptorCopyAttribute

### DIFF
--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -202,7 +202,7 @@ impl CTFontDescriptor {
                 return None
             }
 
-            let value: CFType = TCFType::wrap_under_get_rule(value);
+            let value: CFType = TCFType::wrap_under_create_rule(value);
             assert!(value.instance_of::<CFString>());
             let s: CFString = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
             Some(s.to_string())
@@ -247,7 +247,7 @@ impl CTFontDescriptor {
                 return None;
             }
 
-            let value: CFType = TCFType::wrap_under_get_rule(value);
+            let value: CFType = TCFType::wrap_under_create_rule(value);
             assert!(value.instance_of::<CFURL>());
             let url: CFURL = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
             Some(format!("{:?}", url))


### PR DESCRIPTION
CTFontDescriptorCopyAttribute returns a retained reference (i.e. it
follows the create rule) so were incorrectly retaining it again by using
`wrap_under_get_rule`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/82)
<!-- Reviewable:end -->
