### PR TITLE
Add CTFontDescriptor::traits()

### DIFF
--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -253,6 +253,17 @@ impl CTFontDescriptor {
             Some(format!("{:?}", url))
         }
     }
+
+    pub fn traits(&self) -> CTFontTraits {
+        unsafe {
+            let value = CTFontDescriptorCopyAttribute(self.0, kCTFontTraitsAttribute);
+            assert!(!value.is_null());
+            let value: CFType = TCFType::wrap_under_create_rule(value);
+            assert!(value.instance_of::<CFDictionary>());
+            let dictionary: CFDictionary = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
+            dictionary
+        }
+    }
 }
 
 pub fn new_from_attributes(attributes: &CFDictionary) -> CTFontDescriptor {


### PR DESCRIPTION
This provides easy access to e.g. the font weight.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/83)
<!-- Reviewable:end -->
