### PR TITLE
Use typed wrap_under_{create,get}_rule() functions

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -91,7 +91,7 @@ pub fn new_from_CGFont(cgfont: &CGFont, pt_size: f64) -> CTFont {
                                                     pt_size as CGFloat,
                                                     ptr::null(),
                                                     ptr::null());
-        TCFType::wrap_under_create_rule(font_ref)
+        CTFont::wrap_under_create_rule(font_ref)
     }
 }
 
@@ -100,7 +100,7 @@ pub fn new_from_descriptor(desc: &CTFontDescriptor, pt_size: f64) -> CTFont {
         let font_ref = CTFontCreateWithFontDescriptor(desc.as_concrete_TypeRef(),
                                                       pt_size as CGFloat,
                                                       ptr::null());
-        TCFType::wrap_under_create_rule(font_ref)
+        CTFont::wrap_under_create_rule(font_ref)
     }
 }
 
@@ -113,7 +113,7 @@ pub fn new_from_name(name: &str, pt_size: f64) -> Result<CTFont, ()> {
         if font_ref.is_null() {
             Err(())
         } else {
-            Ok(TCFType::wrap_under_create_rule(font_ref))
+            Ok(CTFont::wrap_under_create_rule(font_ref))
         }
     }
 }
@@ -142,7 +142,7 @@ impl CTFont {
                                                           size as CGFloat,
                                                           ptr::null(),
                                                           ptr::null());
-            TCFType::wrap_under_create_rule(font_ref)
+            CTFont::wrap_under_create_rule(font_ref)
         }
     }
 
@@ -177,7 +177,7 @@ impl CTFont {
 
     pub fn all_traits(&self) -> CTFontTraits {
         unsafe {
-            TCFType::wrap_under_create_rule(CTFontCopyTraits(self.0))
+            CTFontTraits::wrap_under_create_rule(CTFontCopyTraits(self.0))
         }
     }
 
@@ -262,7 +262,7 @@ impl CTFont {
             if result.is_null() {
                 None
             } else {
-                Some(TCFType::wrap_under_create_rule(result))
+                Some(CFData::wrap_under_create_rule(result))
             }
         }
     }
@@ -296,7 +296,7 @@ impl CTFont {
             if result.is_null() {
                 None
             } else {
-                Some(TCFType::wrap_under_create_rule(result as CFURLRef))
+                Some(CFURL::wrap_under_create_rule(result as CFURLRef))
             }
         }
     }
@@ -321,8 +321,7 @@ fn get_string_by_name_key(font: &CTFont, name_key: CFStringRef) -> Option<String
         if result.is_null() {
             None
         } else {
-            let string: CFString = TCFType::wrap_under_create_rule(result);
-            Some(string.to_string())
+            Some(CFString::wrap_under_create_rule(result).to_string())
         }
     }
 }
@@ -362,7 +361,7 @@ pub fn cascade_list_for_languages(font: &CTFont, language_pref_list: &CFArray<CF
         let font_collection_ref =
             CTFontCopyDefaultCascadeListForLanguages(font.as_concrete_TypeRef(),
                                                      language_pref_list.as_concrete_TypeRef());
-        TCFType::wrap_under_create_rule(font_collection_ref)
+        CFArray::wrap_under_create_rule(font_collection_ref)
     }
 }
 
@@ -419,7 +418,7 @@ extern {
                                       matrix: *const CGAffineTransform) -> CTFontRef;
     //fn CTFontCreateWithFontDescriptorAndOptions
     //fn CTFontCreateUIFontForLanguage
-    fn CTFontCreateCopyWithAttributes(font: CTFontRef, size: CGFloat, matrix: *const CGAffineTransform, 
+    fn CTFontCreateCopyWithAttributes(font: CTFontRef, size: CGFloat, matrix: *const CGAffineTransform,
                                       attributes: CTFontDescriptorRef) -> CTFontRef;
     //fn CTFontCreateCopyWithSymbolicTraits
     //fn CTFontCreateCopyWithFamily
@@ -439,7 +438,7 @@ extern {
     //fn CTFontCopyFullName(font: CTFontRef) -> CFStringRef;
     //fn CTFontCopyDisplayName(font: CTFontRef) -> CFStringRef;
     fn CTFontCopyName(font: CTFontRef, nameKey: CFStringRef) -> CFStringRef;
-    //fn CTFontCopyLocalizedName(font: CTFontRef, nameKey: CFStringRef, 
+    //fn CTFontCopyLocalizedName(font: CTFontRef, nameKey: CFStringRef,
     //                           language: *CFStringRef) -> CFStringRef;
     #[cfg(feature = "mountainlion")]
     fn CTFontCopyDefaultCascadeListForLanguages(font: CTFontRef, languagePrefList: CFArrayRef) -> CFArrayRef;
@@ -496,8 +495,8 @@ extern {
     /* Converting Fonts */
     fn CTFontCopyGraphicsFont(font: CTFontRef, attributes: *mut CTFontDescriptorRef)
                               -> CGFontRef;
-    fn CTFontCreateWithGraphicsFont(graphicsFont: CGFontRef, size: CGFloat, 
-                                    matrix: *const CGAffineTransform, 
+    fn CTFontCreateWithGraphicsFont(graphicsFont: CGFontRef, size: CGFloat,
+                                    matrix: *const CGAffineTransform,
                                     attributes: CTFontDescriptorRef) -> CTFontRef;
     //fn CTFontGetPlatformFont
     //fn CTFontCreateWithPlatformFont

--- a/src/font_collection.rs
+++ b/src/font_collection.rs
@@ -38,31 +38,31 @@ impl CTFontCollection {
         // surprise! this function follows the Get rule, despite being named *Create*.
         // So we have to addRef it to avoid CTFontCollection from double freeing it later.
         unsafe {
-            TCFType::wrap_under_get_rule(CTFontCollectionCreateMatchingFontDescriptors(self.0))
+            CFArray::wrap_under_get_rule(CTFontCollectionCreateMatchingFontDescriptors(self.0))
         }
     }
 }
 
 pub fn new_from_descriptors(descs: &CFArray<CTFontDescriptor>) -> CTFontCollection {
     unsafe {
-        let key: CFString = TCFType::wrap_under_get_rule(kCTFontCollectionRemoveDuplicatesOption);
+        let key = CFString::wrap_under_get_rule(kCTFontCollectionRemoveDuplicatesOption);
         let value = CFNumber::from(1i64);
         let options = CFDictionary::from_CFType_pairs(&[ (key.as_CFType(), value.as_CFType()) ]);
         let font_collection_ref =
             CTFontCollectionCreateWithFontDescriptors(descs.as_concrete_TypeRef(),
                                                       options.as_concrete_TypeRef());
-        TCFType::wrap_under_create_rule(font_collection_ref)
+        CTFontCollection::wrap_under_create_rule(font_collection_ref)
     }
 }
 
 pub fn create_for_all_families() -> CTFontCollection {
     unsafe {
-        let key: CFString = TCFType::wrap_under_get_rule(kCTFontCollectionRemoveDuplicatesOption);
+        let key = CFString::wrap_under_get_rule(kCTFontCollectionRemoveDuplicatesOption);
         let value = CFNumber::from(1i64);
         let options = CFDictionary::from_CFType_pairs(&[ (key.as_CFType(), value.as_CFType()) ]);
         let font_collection_ref =
             CTFontCollectionCreateFromAvailableFonts(options.as_concrete_TypeRef());
-        TCFType::wrap_under_create_rule(font_collection_ref)
+        CTFontCollection::wrap_under_create_rule(font_collection_ref)
     }
 }
 
@@ -70,7 +70,7 @@ pub fn create_for_family(family: &str) -> Option<CTFontCollection> {
     use font_descriptor::kCTFontFamilyNameAttribute;
 
     unsafe {
-        let family_attr: CFString = TCFType::wrap_under_get_rule(kCTFontFamilyNameAttribute);
+        let family_attr = CFString::wrap_under_get_rule(kCTFontFamilyNameAttribute);
         let family_name: CFString = family.parse().unwrap();
         let specified_attrs = CFDictionary::from_CFType_pairs(&[
             (family_attr.as_CFType(), family_name.as_CFType())
@@ -85,7 +85,7 @@ pub fn create_for_family(family: &str) -> Option<CTFontCollection> {
         if matched_descs == ptr::null() {
             return None;
         }
-        let matched_descs: CFArray<CTFontDescriptor> = TCFType::wrap_under_create_rule(matched_descs);
+        let matched_descs = CFArray::wrap_under_create_rule(matched_descs);
         // I suppose one doesn't even need the CTFontCollection object at this point.
         // But we stick descriptors into and out of it just to provide a nice wrapper API.
         Some(new_from_descriptors(&matched_descs))
@@ -94,7 +94,7 @@ pub fn create_for_family(family: &str) -> Option<CTFontCollection> {
 
 pub fn get_family_names() -> CFArray<CFString> {
     unsafe {
-        TCFType::wrap_under_create_rule(CTFontManagerCopyAvailableFontFamilyNames())
+        CFArray::wrap_under_create_rule(CTFontManagerCopyAvailableFontFamilyNames())
     }
 }
 
@@ -109,7 +109,7 @@ extern {
     //                                                 descriptors: CFArrayRef,
     //                                                 options: CFDictionaryRef) -> CTFontCollectionRef;
     fn CTFontCollectionCreateFromAvailableFonts(options: CFDictionaryRef) -> CTFontCollectionRef;
-    // this stupid function doesn't actually do any wildcard expansion; 
+    // this stupid function doesn't actually do any wildcard expansion;
     // it just chooses the best match. Use
     // CTFontDescriptorCreateMatchingDescriptors instead.
     fn CTFontCollectionCreateMatchingFontDescriptors(collection: CTFontCollectionRef) -> CFArrayRef;

--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -131,7 +131,7 @@ impl TraitAccessorPrivate for CTFontTraits {
     unsafe fn extract_number_for_key(&self, key: CFStringRef) -> CFNumber {
         let cftype = self.get_CFType(mem::transmute(key));
         assert!(cftype.instance_of::<CFNumber>());
-        TCFType::wrap_under_get_rule(mem::transmute(cftype.as_CFTypeRef()))
+        CFNumber::wrap_under_get_rule(mem::transmute(cftype.as_CFTypeRef()))
     }
 
 }
@@ -202,9 +202,9 @@ impl CTFontDescriptor {
                 return None
             }
 
-            let value: CFType = TCFType::wrap_under_create_rule(value);
+            let value = CFType::wrap_under_create_rule(value);
             assert!(value.instance_of::<CFString>());
-            let s: CFString = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
+            let s = CFString::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
             Some(s.to_string())
         }
     }
@@ -247,9 +247,9 @@ impl CTFontDescriptor {
                 return None;
             }
 
-            let value: CFType = TCFType::wrap_under_create_rule(value);
+            let value = CFType::wrap_under_create_rule(value);
             assert!(value.instance_of::<CFURL>());
-            let url: CFURL = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
+            let url = CFURL::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
             Some(format!("{:?}", url))
         }
     }
@@ -258,10 +258,9 @@ impl CTFontDescriptor {
         unsafe {
             let value = CTFontDescriptorCopyAttribute(self.0, kCTFontTraitsAttribute);
             assert!(!value.is_null());
-            let value: CFType = TCFType::wrap_under_create_rule(value);
+            let value = CFType::wrap_under_create_rule(value);
             assert!(value.instance_of::<CFDictionary>());
-            let dictionary: CFDictionary = TCFType::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
-            dictionary
+            CFDictionary::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()))
         }
     }
 }
@@ -270,7 +269,7 @@ pub fn new_from_attributes(attributes: &CFDictionary) -> CTFontDescriptor {
     unsafe {
         let result: CTFontDescriptorRef =
             CTFontDescriptorCreateWithAttributes(attributes.as_concrete_TypeRef());
-        TCFType::wrap_under_create_rule(result)
+        CTFontDescriptor::wrap_under_create_rule(result)
     }
 }
 


### PR DESCRIPTION
Just some minor cleanup; no functional changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/84)
<!-- Reviewable:end -->
