### PR TITLE
Make CTFontDescriptor::font_path() return filesystem path, not URL

### DIFF
--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -15,7 +15,7 @@ use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::number::{CFNumber, CFNumberRef};
 use core_foundation::set::CFSetRef;
 use core_foundation::string::{CFString, CFStringRef};
-use core_foundation::url::CFURL;
+use core_foundation::url::{CFURLCopyFileSystemPath, kCFURLPOSIXPathStyle, CFURL};
 use core_graphics::base::CGFloat;
 
 use libc::c_void;
@@ -250,7 +250,11 @@ impl CTFontDescriptor {
             let value = CFType::wrap_under_create_rule(value);
             assert!(value.instance_of::<CFURL>());
             let url = CFURL::wrap_under_get_rule(mem::transmute(value.as_CFTypeRef()));
-            Some(format!("{:?}", url))
+            let path = CFString::wrap_under_create_rule(CFURLCopyFileSystemPath(
+                url.as_concrete_TypeRef(),
+                kCFURLPOSIXPathStyle,
+            )).to_string();
+            Some(path)
         }
     }
 


### PR DESCRIPTION
Prior to this commit, the return string was in the format
`file:///foo/bar.otf`. We now omit the leading `file://` portion. This
also properly retains characters that are not URL safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/85)
<!-- Reviewable:end -->
