### PR TITLE
allow creating a CTFont from a CGFont with variations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "9.1.0"
+version = "9.2.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"

--- a/src/font.rs
+++ b/src/font.rs
@@ -9,13 +9,14 @@
 
 #![allow(non_upper_case_globals)]
 
+use font_descriptor;
 use font_descriptor::{CTFontDescriptor, CTFontDescriptorRef, CTFontOrientation};
 use font_descriptor::{CTFontSymbolicTraits, CTFontTraits, SymbolicTraitAccessors, TraitAccessors};
 
 use core_foundation::array::{CFArray, CFArrayRef};
 use core_foundation::base::{CFIndex, CFOptionFlags, CFTypeID, CFTypeRef, TCFType};
 use core_foundation::data::{CFData, CFDataRef};
-use core_foundation::dictionary::CFDictionaryRef;
+use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::{CFString, CFStringRef, UniChar};
 use core_foundation::url::{CFURL, CFURLRef};
 use core_graphics::base::CGFloat;
@@ -91,6 +92,20 @@ pub fn new_from_CGFont(cgfont: &CGFont, pt_size: f64) -> CTFont {
                                                     pt_size as CGFloat,
                                                     ptr::null(),
                                                     ptr::null());
+        CTFont::wrap_under_create_rule(font_ref)
+    }
+}
+
+pub fn new_from_CGFont_with_variations(cgfont: &CGFont,
+                                       pt_size: f64,
+                                       variations: &CFDictionary)
+                                       -> CTFont {
+    unsafe {
+        let font_desc = font_descriptor::new_from_variations(variations);
+        let font_ref = CTFontCreateWithGraphicsFont(cgfont.as_ptr() as *mut _,
+                                                    pt_size as CGFloat,
+                                                    ptr::null(),
+                                                    font_desc.as_concrete_TypeRef());
         CTFont::wrap_under_create_rule(font_ref)
     }
 }

--- a/src/font_descriptor.rs
+++ b/src/font_descriptor.rs
@@ -277,6 +277,15 @@ pub fn new_from_attributes(attributes: &CFDictionary) -> CTFontDescriptor {
     }
 }
 
+pub fn new_from_variations(variations: &CFDictionary) -> CTFontDescriptor {
+    unsafe {
+        let var_key = CFType::wrap_under_get_rule(mem::transmute(kCTFontVariationAttribute));
+        let var_val = CFType::wrap_under_get_rule(variations.as_CFTypeRef());
+        let attributes = CFDictionary::from_CFType_pairs(&[(var_key, var_val)]);
+        new_from_attributes(&attributes)
+    }
+}
+
 pub fn debug_descriptor(desc: &CTFontDescriptor) {
     println!("family: {}", desc.family_name());
     println!("name: {}", desc.font_name());


### PR DESCRIPTION
This is functionality necessary to solve https://bugzilla.mozilla.org/show_bug.cgi?id=1435062

We need to be able to pass the variations dictionary to the CTFont, otherwise core-text does not properly handle with the variations on the font.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-text-rs/86)
<!-- Reviewable:end -->
